### PR TITLE
Add more (types of) hub links

### DIFF
--- a/hub_map.html
+++ b/hub_map.html
@@ -383,8 +383,7 @@ $(document).ready(function() {
 
     $.ajax({
         type: "GET",
-        url: "https://docs.google.com/spreadsheets/d/1v3Q72p9HvE966bak37E_h1qLpRtF_i935zzGrON3VpI/export?exportFormat=csv",
-        //url: "https://docs.google.com/spreadsheets/d/1ZX3bzLhbnq1MICD_siWDw2hxeP0SGXGoHyuXpzp-rzA/export?exportFormat=csv",
+        url: "https://docs.google.com/spreadsheets/d/1ZX3bzLhbnq1MICD_siWDw2hxeP0SGXGoHyuXpzp-rzA/export?exportFormat=csv",
         dataType: "text",
         success: function(data) {
           var lines = processData(data);

--- a/hub_map.html
+++ b/hub_map.html
@@ -383,7 +383,8 @@ $(document).ready(function() {
 
     $.ajax({
         type: "GET",
-        url: "https://docs.google.com/spreadsheets/d/1ZX3bzLhbnq1MICD_siWDw2hxeP0SGXGoHyuXpzp-rzA/export?exportFormat=csv",
+        url: "https://docs.google.com/spreadsheets/d/1v3Q72p9HvE966bak37E_h1qLpRtF_i935zzGrON3VpI/export?exportFormat=csv",
+        //url: "https://docs.google.com/spreadsheets/d/1ZX3bzLhbnq1MICD_siWDw2hxeP0SGXGoHyuXpzp-rzA/export?exportFormat=csv",
         dataType: "text",
         success: function(data) {
           var lines = processData(data);

--- a/hub_map.html
+++ b/hub_map.html
@@ -324,6 +324,7 @@ function makeGeoJSONFeature(coordinatorLines) {
   var websiteEmail = line[10].trim();
   var websiteLink = line[11].trim();
   var twitterLink = line[12].trim();
+  var instagramLink = line[13].trim();
 
   var coordinatorsHtml = "<span style='font-size: 16px'>Hub Contact";
   if(coordinatorLines.length > 1) { coordinatorsHtml += "s"; }
@@ -357,7 +358,8 @@ function makeGeoJSONFeature(coordinatorLines) {
           "coordinators": coordinatorsHtml,
           "facebookGroupLink": facebookGroupLink,
           "twitterLink": twitterLink,
-          "websiteLink": websiteLink
+          "websiteLink": websiteLink,
+          "instagramLink": instagramLink
         }
       }
   return feature;
@@ -500,6 +502,7 @@ function initMap(hubs) {
     var fbLink = properties.facebookGroupLink;
     var twLink = properties.twitterLink;
     var wsLink = properties.websiteLink;
+    var igLink = properties.instagramLink;
     if (fbLink) {
       html += '<p><a href="'+ fbLink + '" target="_blank" style="text-decoration:underline;">Facebook Page</a></p>';
     }
@@ -508,6 +511,13 @@ function initMap(hubs) {
         html += '<p><a href="https://twitter.com/'+ twLink.slice(1) + '" target="_blank" style="text-decoration:underline;">Twitter Page</a></p>';
       } else {
         html += '<p><a href="'+ twLink + '" target="_blank" style="text-decoration:underline;">Twitter Page</a></p>';
+      }
+    }
+    if (igLink) {
+      if (igLink.startsWith("@")) {
+        html += '<p><a href="https://www.instagram.com/'+ igLink.slice(1) + '" target="_blank" style="text-decoration:underline;">Instagram Page</a></p>';
+      } else {
+        html += '<p><a href="'+ igLink + '" target="_blank" style="text-decoration:underline;">Instagram Page</a></p>';
       }
     }
     if (wsLink) {

--- a/hub_map.html
+++ b/hub_map.html
@@ -316,22 +316,24 @@ function emailLink(email) {
 
 function makeGeoJSONFeature(coordinatorLines) {
   var line = coordinatorLines[0];
-  var state = line[0];
-  var city = line[1];
+  var state = line[0].trim();
+  var city = line[1].trim();
   var lat = parseFloat(line[2].replace(/"/, ""));
   var lng = parseFloat(line[3].replace(/"/, ""));
-  var facebookGroupLink = line[9];
-  var websiteEmail = line[10];
-  
+  var facebookGroupLink = line[9].trim();
+  var websiteEmail = line[10].trim();
+  var websiteLink = line[11].trim();
+  var twitterLink = line[12].trim();
+
   var coordinatorsHtml = "<span style='font-size: 16px'>Hub Contact";
   if(coordinatorLines.length > 1) { coordinatorsHtml += "s"; }
   coordinatorsHtml += ":</span><p>";
   for (var i=0; i < coordinatorLines.length; i++) {
     var coordinatorLine = coordinatorLines[i];
-    var firstName = coordinatorLine[4];
-    var lastName = coordinatorLine[5];
-    var email = coordinatorLine[6];
-    var phone = coordinatorLine[7];
+    var firstName = coordinatorLine[4].trim();
+    var lastName = coordinatorLine[5].trim();
+    var email = coordinatorLine[6].trim();
+    var phone = coordinatorLine[7].trim();
     //var preferredContactMode = coordinatorLine[8];
     
     coordinatorsHtml += "<strong>" + firstName + " " + lastName + "</strong>: ";
@@ -353,7 +355,9 @@ function makeGeoJSONFeature(coordinatorLines) {
         "properties": {
           "address": city + ", " + state,
           "coordinators": coordinatorsHtml,
-          "facebookGroupLink": facebookGroupLink
+          "facebookGroupLink": facebookGroupLink,
+          "twitterLink": twitterLink,
+          "websiteLink": websiteLink
         }
       }
   return feature;
@@ -491,15 +495,25 @@ function initMap(hubs) {
       });
   }
 
-  function groupLinkHtml(groupLink) {
-    // TODO: rename spreadsheet column in original CSV to account for non-facebook links
-    if (/facebook\.com/i.test(groupLink)) { // Facebook
-      return '<p><a href="'+ groupLink + '" target="_blank" style="text-decoration:underline;">Facebook Page</a></p>';
-    } else if (groupLink.trim().startsWith("@")) { // Twitter
-      return '<p><a href="https://twitter.com/'+ groupLink.trim().slice(1) + '" target="_blank" style="text-decoration:underline;">Twitter Page</a></p>';
-    } else { // Other website
-      return '<p><a href="'+ groupLink + '" target="_blank" style="text-decoration:underline;">Hub Website</a></p>';
+  function groupLinkHtml(properties) {
+    var html = '';
+    var fbLink = properties.facebookGroupLink;
+    var twLink = properties.twitterLink;
+    var wsLink = properties.websiteLink;
+    if (fbLink) {
+      html += '<p><a href="'+ fbLink + '" target="_blank" style="text-decoration:underline;">Facebook Page</a></p>';
     }
+    if (twLink) {
+      if (twLink.startsWith("@")) {
+        html += '<p><a href="https://twitter.com/'+ twLink.slice(1) + '" target="_blank" style="text-decoration:underline;">Twitter Page</a></p>';
+      } else {
+        html += '<p><a href="'+ twLink + '" target="_blank" style="text-decoration:underline;">Twitter Page</a></p>';
+      }
+    }
+    if (wsLink) {
+      html += '<p><a href="'+ wsLink + '" target="_blank" style="text-decoration:underline;">Hub Website</a></p>';
+    }
+    return html;
   }
 
   function createPopUp(currentFeature) {
@@ -508,9 +522,7 @@ function initMap(hubs) {
 
     var popupHtml = "<h3>" + currentFeature.properties.address + "</h3><h4>";
 
-    if(currentFeature.properties.facebookGroupLink) {
-      popupHtml += groupLinkHtml(currentFeature.properties.facebookGroupLink);
-    }
+    popupHtml += groupLinkHtml(currentFeature.properties);
 
     popupHtml += currentFeature.properties.coordinators + '</h4>';
 
@@ -545,9 +557,7 @@ function initMap(hubs) {
       coordinatorsDivMobile.className = 'coordinators-mobile';
 
       var hubListItemHtml = "";
-      if(prop.facebookGroupLink) {
-        hubListItemHtml += groupLinkHtml(prop.facebookGroupLink);
-      }
+      hubListItemHtml += groupLinkHtml(prop);
       hubListItemHtml += prop.coordinators;
 
       coordinatorsDivMobile.innerHTML = hubListItemHtml;


### PR DESCRIPTION
The main code update for this pull request is to allow multiple kinds of links (beyond just Facebook).

However, when developing the previous map feature, I noticed that very few hubs actually had any kind of link listed -- in fact, we only had links for only 20 out of 204. However, when I googled around, I immediately found that many of the hubs actually did appear to have active social media presences.

~~Link data is pulled from [a google spreadsheet](https://docs.google.com/spreadsheets/d/1ZX3bzLhbnq1MICD_siWDw2hxeP0SGXGoHyuXpzp-rzA/edit), so I [made a copy](https://docs.google.com/spreadsheets/d/1v3Q72p9HvE966bak37E_h1qLpRtF_i935zzGrON3VpI/edit#gid=0) and filled it in with links I found by googling (in a reasonably streamlined process :P). This brings us up from 20 links to 99!~~ 

~~The changes are available for review [here](https://testing-sunrise-webfeats.s3.amazonaws.com/index.html). If folks approve these changes, I'm thinking we can mass-email hub coordinators and ask them to let us know if any information is incorrect/needs to be updated. We can resolve any issues they report, then after a few days, we can copy/paste the new data back into the original spreadsheet. Then we will have 5x the previous number of hub links, or more if coordinators email us back with additions!~~

Update: per consultation with Nicole (one of the maintainers of the hub spreadsheet), we went ahead and added the links directly. So the only changes from this PR are to show website/twitter/instagram links! We might still email hub coordinators afterwards to see if they want to make any changes.
