### PR TITLE
Simple attempt at tracking when different hubs get viewed on map

### DIFF
--- a/hub_map.html
+++ b/hub_map.html
@@ -544,6 +544,10 @@ function initMap(hubs) {
       .setLngLat(currentFeature.geometry.coordinates)
       .setHTML(popupHtml)
       .addTo(map);
+
+    if (window.ga) {
+      ga('send', 'event', 'hubmap', 'hubview', currentFeature.properties.address);
+    }
   }
 
 


### PR DESCRIPTION
I'm not 100% sure if this is the right way to handle this, but basically, the goal is to be able to track when people view hub cards in the hub map. Right now we don't know how many people use this feature or which areas of the country they're most interested in, and adding a tiny amount of analytics should give us some visibility into that!